### PR TITLE
Bugfix: Creating orders doesn't erase user passwords anymore.

### DIFF
--- a/FribergCarRentalsBravo.Data/Repositories/OrderRepository.cs
+++ b/FribergCarRentalsBravo.Data/Repositories/OrderRepository.cs
@@ -26,6 +26,7 @@ namespace FribergCarRentalsBravo.DataAccess.Repositories
                 throw new Exception("Can't create an order for an inactive car.");
             }
 
+            applicationDbContext.ChangeTracker.AutoDetectChangesEnabled = false;
             applicationDbContext.Attach(order.Car);
             applicationDbContext.Attach(order.Customer);
             applicationDbContext.Add(order);


### PR DESCRIPTION
EF Core detected that the customer object for the incoming order object had an empty password and detected that as a change and erased the password, despite the whole customer entity having a status of unchanged. EF Core is now instructed to not detect changes.